### PR TITLE
Hide exception after disconnect

### DIFF
--- a/Waitingway/Waitingway.csproj
+++ b/Waitingway/Waitingway.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Dalamud.NET.Sdk/14.0.1">
   <PropertyGroup>
     <Authors>Asriel Camora</Authors>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <PackageProjectUrl>https://github.com/WorkingRobot/Waitingway</PackageProjectUrl>
     <Configurations>Debug;Release</Configurations>
     <AssemblyName>Waitingway.Dalamud</AssemblyName>

--- a/Waitingway/Windows/Queue.cs
+++ b/Waitingway/Windows/Queue.cs
@@ -29,6 +29,9 @@ public sealed unsafe class Queue : Window, IDisposable
         if (Service.LoginTracker.CurrentState == LoginQueueTracker.QueueState.NotQueued)
             return false;
 
+        if (Service.LoginTracker.CurrentRecap?.CurrentPosition is null)
+            return false;
+
         var addon = (AtkUnitBase*)Service.GameGui.GetAddonByName("SelectOk").Address;
         if (addon == null)
             return false;


### PR DESCRIPTION
This PR will hide the error window displayed while logging in right after a disconnect.

This is done by checking for `Service.LoginTracker.CurrentRecap?.CurrentPosition` being `null` during `DrawCondition()`

